### PR TITLE
Refactor Constants to Use Environment Variables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module cchalop1.com/deploy
 
-go 1.21.3
+go 1.23
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect

--- a/internal/env.go
+++ b/internal/env.go
@@ -1,7 +1,9 @@
 package internal
 
-const JUSTDEPLOY_FOLDER = "/Users/cchalop1/.config/" + "justdeploy"
+import "os"
 
-const CERT_DOCKER_FOLDER = JUSTDEPLOY_FOLDER + "/cert-docker"
+var JUSTDEPLOY_FOLDER = os.Getenv("HOME") + "/xs.config/" + "justdeploy"
 
-const DATABASE_FILE_PATH = JUSTDEPLOY_FOLDER + "/database.json"
+var CERT_DOCKER_FOLDER = JUSTDEPLOY_FOLDER + "/cert-docker"
+
+var DATABASE_FILE_PATH = JUSTDEPLOY_FOLDER + "/database.json"


### PR DESCRIPTION
I tried using JustDeploy and I hit this issue:
<img width="1106" alt="image" src="https://github.com/user-attachments/assets/82fcc0e4-357e-4ac8-8e6d-8aab2c3a3feb">

This pull request refactors the env file to replace hard-coded path constants with environment variable-based paths.